### PR TITLE
add a flatmenu unittest to show crash when one does e.g. a flatmenu.Popup

### DIFF
--- a/unittests/test_lib_agw_flatmenu.py
+++ b/unittests/test_lib_agw_flatmenu.py
@@ -31,6 +31,38 @@ class lib_agw_flatmenu_Tests(wtc.WidgetTestCase):
 
         self._popUpMenu.AppendSeparator()
                         
+    def test_lib_agw_flatmenuOpen(self):
+        def CreateLongPopupMenu(self):
+            popMenu = FM.FlatMenu()
+            sub = FM.FlatMenu()
+    
+            #-----------------------------------------------
+            # Flat Menu test
+            #-----------------------------------------------
+    
+            for ii in range(30):
+                if ii == 0:
+                    menuItem = FM.FlatMenuItem(popMenu, wx.ID_ANY, "Menu Item #%ld"%(ii+1), "", wx.ITEM_NORMAL, sub)
+                    popMenu.AppendItem(menuItem)
+    
+                    for k in range(5):
+    
+                        menuItem = FM.FlatMenuItem(sub, wx.ID_ANY, "Sub Menu Item #%ld"%(k+1))
+                        sub.AppendItem(menuItem)
+    
+                else:
+    
+                    menuItem = FM.FlatMenuItem(popMenu, wx.ID_ANY, "Menu Item #%ld"%(ii+1))
+                    popMenu.AppendItem(menuItem)
+    
+            return popMenu
+
+        popMenu = CreateLongPopupMenu(self)
+        
+        fPt = self.frame.GetPosition()
+        popMenu.Popup(wx.Point(fPt.x, fPt.y), self.frame)
+    
+
     def test_lib_agw_flatmenuConstantsExist(self):
 
         FM.FM_OPT_IS_LCD
@@ -44,6 +76,7 @@ class lib_agw_flatmenu_Tests(wtc.WidgetTestCase):
         FM.EVT_FLAT_MENU_ITEM_MOUSE_OUT
         FM.EVT_FLAT_MENU_ITEM_MOUSE_OVER
         FM.EVT_FLAT_MENU_SELECTED
+
         
 #---------------------------------------------------------------------------
 

--- a/unittests/test_lib_agw_flatmenu.py
+++ b/unittests/test_lib_agw_flatmenu.py
@@ -30,7 +30,8 @@ class lib_agw_flatmenu_Tests(wtc.WidgetTestCase):
         self._popUpMenu.AppendItem(menuItem)
 
         self._popUpMenu.AppendSeparator()
-                        
+
+    @unittest.skip('crash on opening a menu, at line 5442 in agw.flatmenu ...')        
     def test_lib_agw_flatmenuOpen(self):
         def CreateLongPopupMenu(self):
             popMenu = FM.FlatMenu()

--- a/wx/lib/agw/flatmenu.py
+++ b/wx/lib/agw/flatmenu.py
@@ -4276,7 +4276,8 @@ class FlatMenuBase(ShadowPopupWindow):
         """
 
         # some controls update themselves from OnIdle() call - let them do it
-        wx.GetApp().GetMainLoop().ProcessIdle()
+        if wx.GetApp().GetMainLoop():
+            wx.GetApp().GetMainLoop().ProcessIdle()
 
         # The mouse was pressed in the parent coordinates, 
         # e.g. pressing on the left top of a text ctrl


### PR DESCRIPTION
- in lib.agw.flatmenu needed to test GetMainLoop as it returns None during test