### PR TITLE
masked.timectrl

### DIFF
--- a/unittests/test_lib_masked.py
+++ b/unittests/test_lib_masked.py
@@ -96,6 +96,17 @@ class MaskedTimeCtrlTests(wtc.WidgetTestCase):
         #t.Create(self.frame)
         
         
+    def test_timectrlIsValid(self):
+        t = m.TimeCtrl(self.frame, -1, "18:25:18")
+
+        theTime = t.GetValue(as_wxDateTime=True)
+        self.assertEqual(theTime.hour, 18, "Hour: %s instead of '18'" % theTime.hour)
+        self.assertEqual(theTime.minute, 25, "Minutes: %s instead of '18'" % theTime.minute)
+        self.assertEqual(theTime.second, 18, "Seconds: %s instead of '18'" % theTime.second)
+
+        self.assertEqual(t.IsInBounds(), True)
+
+
     def test_timectrlProperties(self):
         t = m.TimeCtrl(self.frame)
         

--- a/unittests/test_lib_masked.py
+++ b/unittests/test_lib_masked.py
@@ -95,7 +95,6 @@ class MaskedTimeCtrlTests(wtc.WidgetTestCase):
         #t = m.TextCtrl()
         #t.Create(self.frame)
         
-        
     def test_timectrlIsValid(self):
         t = m.TimeCtrl(self.frame, -1, "18:25:18")
 
@@ -105,7 +104,7 @@ class MaskedTimeCtrlTests(wtc.WidgetTestCase):
         self.assertEqual(theTime.second, 18, "Seconds: %s instead of '18'" % theTime.second)
 
         self.assertEqual(t.IsInBounds(), True)
-
+        self.assertEqual(t.GetCtrlParameter('validBackgroundColour'), t.GetBackgroundColour())
 
     def test_timectrlProperties(self):
         t = m.TimeCtrl(self.frame)

--- a/wx/lib/masked/timectrl.py
+++ b/wx/lib/masked/timectrl.py
@@ -1254,7 +1254,7 @@ class TimeCtrl(BaseMaskedTextCtrl):
     def __OnChar(self, event):
         """
         Handler to explicitly look for ':' keyevents, and if found,
-        clear the m_shiftDown field, so it will behave as forward tab.
+        clear the shiftDown field, so it will behave as forward tab.
         It then calls the base control's _OnChar routine with the modified
         event instance.
         """
@@ -1263,7 +1263,7 @@ class TimeCtrl(BaseMaskedTextCtrl):
 ##        dbg('keycode:', keycode)
         if keycode == ord(':'):
 ##            dbg('colon seen! removing shift attribute')
-            event.m_shiftDown = False
+            event.shiftDown = False
         BaseMaskedTextCtrl._OnChar(self, event )              ## handle each keypress
 ##        dbg(indent=0)
 


### PR DESCRIPTION
- better unittest, check for valid color which currently is not working
- need a correction in maskededit._validateTime and probably also in _validateDate, they use wx.DateTime.Parse* which just returns True/False we need to get at how far the input was passed, i.e. was it passed to the end or not.  See message on wxPython-dev