### PR TITLE
Prevent TabFrame being visible

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -2653,7 +2653,7 @@ class TabFrame(wx.Window):
         self._tab_rect = wx.Rect()
         self._parent = parent
 
-        self.Create(parent)
+        self.Create(parent, size=(0, 0))
 
 
     def SetTabCtrlHeight(self, h):


### PR DESCRIPTION
With Phoenix, the TabFrame is unintentionally visible in the top left corner (visible as horizontal and vertical lines with a length of 20px each that are lighter than the border color if tabs are at the top, or as a 20x20px square if tabs are at the bottom). Setting its size to 0, 0 prevents this.