### PR TITLE
agw-persist - allow save/restore of an individual control's value

### DIFF
--- a/unittests/test_lib_agw_persist_persistencemanager.py
+++ b/unittests/test_lib_agw_persist_persistencemanager.py
@@ -13,6 +13,7 @@ class lib_agw_persist_persistencemanager_Tests(wtc.WidgetTestCase):
     def test_lib_agw_persist_persistencemanagerCtor(self):
 
         self._persistMgr = PM.PersistenceManager.Get()
+        self._persistMgr.SetManagerStyle(PM.PM_SAVE_RESTORE_AUI_PERSPECTIVES)
         
         dirName, fileName = os.path.split(os.path.abspath(__file__))
         _configFile1 = os.path.join(dirName, "PersistTest1")
@@ -20,6 +21,9 @@ class lib_agw_persist_persistencemanager_Tests(wtc.WidgetTestCase):
         
         # give the frame a Name for below
         self.frame.SetName('PersistTestFrame')
+        cb = wx.CheckBox(self.frame, name='PersistCheck')
+        cb.persistValue = True
+        cb.SetValue(False)
         
         self._persistMgr.RegisterAndRestoreAll(self.frame)
         
@@ -40,6 +44,26 @@ class lib_agw_persist_persistencemanager_Tests(wtc.WidgetTestCase):
         self._persistMgr.RegisterAndRestoreAll(self.frame)
                 
         self.assertEqual(self._persistMgr.HasRestored(), True, "Persistence should be there, as it was created in CTOR test.")
+
+    def test_lib_agw_persist_persistencemanagerPersistValue(self):
+
+        self._persistMgr = PM.PersistenceManager.Get()
+        self._persistMgr.SetManagerStyle(PM.PM_SAVE_RESTORE_AUI_PERSPECTIVES)        
+        
+        dirName, fileName = os.path.split(os.path.abspath(__file__))
+        _configFile1 = os.path.join(dirName, "PersistTest1")
+        self._persistMgr.SetPersistenceFile(_configFile1)
+        
+        # give the frame a Name for below
+        self.frame.SetName('PersistTestFrame')
+        cb = wx.CheckBox(self.frame, name='PersistCheck')
+        cb.persistValue = True 
+        
+        self._persistMgr.RegisterAndRestoreAll(self.frame)
+                
+        self.assertEqual(self._persistMgr.HasRestored(), True, "Persistence should be there, as it was created in CTOR test.")
+        self.assertEqual(cb.GetValue(), False, "Should be False as set in CTOR test")
+        
 
     def test_lib_agw_persist_persistencemanagerConstantsExist(self):
         # PersistenceManager styles

--- a/wx/lib/agw/persist/persist_handlers.py
+++ b/wx/lib/agw/persist/persist_handlers.py
@@ -125,6 +125,8 @@ class AbstractHandler(object):
         object.__init__(self)
         self._pObject = pObject
         self._window = pObject.GetWindow()
+        if not hasattr(self._window, 'persistValue'):
+            self._window.persistValue = None        
 
         # need to move the import to here, otherwise we error in Python 3
         from . import persistencemanager as PM

--- a/wx/lib/agw/persist/persistencemanager.py
+++ b/wx/lib/agw/persist/persistencemanager.py
@@ -245,6 +245,10 @@ class PersistenceManager(object):
           ``PM_DEFAULT_STYLE``                     Same as ``PM_SAVE_RESTORE_AUI_PERSPECTIVES``
           ======================================== ==================================
 
+        :note: An individual window can also set the variable `persistValue` to
+         indicate that its value should be saved/restored even so the style
+         `PM_PERSIST_CONTROL_VALUE` is not set.
+
         :note: UI settings are stored as dictionaries key <=> tuple: the tuple value
          contains two items. The first is the value *type* (i.e., float, int, bool etc...)
          while the second is the actual key value.
@@ -734,7 +738,10 @@ class PersistenceManager(object):
 
     def SaveCtrlValue(self, obj, keyName, value):
         """
-        Check if we persist the widget value, if so pass it to :meth:`~PersistenceManager.DoSaveValue`.
+        Check if we persist the widget value, if so pass it to :meth:`~PersistenceManager.DoSaveValue`,
+        this method checks the style `PM_PERSIST_CONTROL_VALUE` and if it is not
+        set it will also check the variable `persistValue` of the individual
+        window.
 
         :param `obj`: an instance of :class:`PersistentObject`;
         :param `keyName`: a string specifying the key name;
@@ -742,6 +749,9 @@ class PersistenceManager(object):
         """
 
         if self._style & PM_PERSIST_CONTROL_VALUE:
+            return self.DoSaveValue(obj, keyName, value)
+        elif obj._window.persistValue:
+            # an individual control wants to be saved
             return self.DoSaveValue(obj, keyName, value)
 
 
@@ -784,13 +794,19 @@ class PersistenceManager(object):
 
     def RestoreCtrlValue(self, obj, keyName):
         """
-        Check if we persist the widget value, if so pass it to :meth:`~PersistenceManager.DoRestoreValue`.
-
+        Check if we should restore the widget value, if so pass it to :meth:`~PersistenceManager.DoRestoreValue`,
+        this method checks the style `PM_PERSIST_CONTROL_VALUE` and if if it is
+        not set it will also check the variable `persistValue` of the individual
+        window.
+ 
         :param `obj`: an instance of :class:`PersistentObject`;
         :param `keyName`: a string specifying the key name.
         """
 
         if self._style & PM_PERSIST_CONTROL_VALUE:
+            return self.DoRestoreValue(obj, keyName)
+        elif obj._window.persistValue:
+            # an individual control wants to be saved
             return self.DoRestoreValue(obj, keyName)
 
 


### PR DESCRIPTION
Allow that an individual controls saves/restores its value (got into SVN at some point)