### PR TITLE
Added check for mgr in close procedure

### DIFF
--- a/wx/lib/inspection.py
+++ b/wx/lib/inspection.py
@@ -427,10 +427,11 @@ class InspectionFrame(wx.Frame):
             px, py = self.GetPosition()
             config.WriteInt('Window/PosX', px)
             config.WriteInt('Window/PosY', py)
-
-        perspective = self.mgr.SavePerspective()
-        config.Write('perspective', perspective)
-        config.WriteBool('includeSizers', self.includeSizers)
+        
+        if hasattr(self, "mgr"):
+            perspective = self.mgr.SavePerspective()
+            config.Write('perspective', perspective)
+            config.WriteBool('includeSizers', self.includeSizers)
 
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
Added to resolve the following error:
Traceback (most recent call last):
  File "/users/dunnsa/lib/python3.5/site-packages/wx/lib/inspection.py", line 278, in OnClose
    self.SaveSettings(self.config)
  File "/users/dunnsa/lib/python3.5/site-packages/wx/lib/inspection.py", line 431, in SaveSettings
    perspective = self.mgr.SavePerspective()
AttributeError: 'InspectionFrame' object has no attribute 'mgr'


Still not sure why this happening, and I'm more inclined to believe it a fault in my TLW's close process. 
However it has happened on two different machines (both wxGTK) under a normal user close event.