### PR TITLE
Allow Py-like reverse indexing of wxList

### DIFF
--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -873,9 +873,12 @@ public:
         sipRes = sipCpp->size();
     %End
 
-    {ItemClass}* __getitem__(ulong index);
+    {ItemClass}* __getitem__(long index);
     %MethodCode
-        if (index < sipCpp->size()) {{
+        if (0 > index)
+            index += sipCpp->size();
+
+        if (index < sipCpp->size() && (0 <= index)) {{
             {ListClass}::compatibility_iterator node = sipCpp->Item(index);
             if (node)
                 sipRes = ({ItemClass}*)node->GetData();


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Adds py-like indexing (eg. -1->last element) to wxList via wxListWrapperTemplate. 


Let me know if you'd like the same for wxArrayWrapperTemplate.