### PR TITLE
Fix the use of the output parameter in HtmlWindow.OnOpeningURL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Changes in this release include the following:
 * Updated wxWidgets commit reference, bringing fixes for #1140, #1086 and 
   #1147.
 
+* Fix the use of the output parameter in HtmlWindow.OnOpeningURL the same way 
+  it was fixed in HtmlWindowInterface.OnHTMLOpeningURL. (#1068)
+  
   
 
 

--- a/etg/htmlwin.py
+++ b/etg/htmlwin.py
@@ -48,6 +48,8 @@ def run():
     tools.fixHtmlSetFonts(c)
 
     c.find('AddFilter.filter').transfer = True
+    c.find('OnOpeningURL.redirect').out = True
+    c.find('OnOpeningURL.redirect').name = 'redirectTo'
 
     # Turn the virtual flag back on for some methods
     for name in [ 'OnLinkClicked',


### PR DESCRIPTION
Fix the use of the output parameter in HtmlWindow.OnOpeningURL the same way it was fixed in HtmlWindowInterface.OnHTMLOpeningURL.

Fixes #1068